### PR TITLE
[add] prius message converter

### DIFF
--- a/prius_msg_converter/CMakeLists.txt
+++ b/prius_msg_converter/CMakeLists.txt
@@ -1,0 +1,52 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(prius_msg_converter)
+
+add_compile_options(-std=c++11)
+
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+  prius_msgs
+  geometry_msgs
+  nav_msgs
+)
+
+###################################
+## catkin specific configuration ##
+###################################
+catkin_package(
+CATKIN_DEPENDS roscpp prius_msgs geometry_msgs nav_msgs
+)
+
+###########
+## Build ##
+###########
+include_directories(
+  include
+  ${catkin_INCLUDE_DIRS}
+)
+
+set(prius_msg_to_cmd_vel_src
+  src/to_cmd_vel.cpp
+  src/to_cmd_vel_node.cpp
+  )
+add_executable(prius_msg_to_cmd_vel ${prius_msg_to_cmd_vel_src})
+target_link_libraries(prius_msg_to_cmd_vel ${catkin_LIBRARIES})
+
+#############
+## Install ##
+#############
+install(DIRECTORY include
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  )
+foreach(dir launch)
+  install(DIRECTORY ${dir}/
+    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})
+endforeach(dir)
+
+#############
+## Testing ##
+#############
+if (CATKIN_ENABLE_TESTING)
+  find_package(roslaunch REQUIRED)
+  roslaunch_add_file_check(launch)
+endif()

--- a/prius_msg_converter/include/to_cmd_vel.hpp
+++ b/prius_msg_converter/include/to_cmd_vel.hpp
@@ -1,0 +1,56 @@
+#ifndef TO_CMD_VEL_HPP_INCLUDED
+#define TO_CMD_VEL_HPP_INCLUDED
+
+// usual header for ROS
+#include <ros/ros.h>
+
+// messages to use
+#include <prius_msgs/Control.h>
+#include <geometry_msgs/Twist.h>
+#include <nav_msgs/Odometry.h>
+
+// for std lib
+#include <iostream>
+#include <mutex>
+
+
+namespace prius {
+  namespace msg_converter {
+    class ToCmdVel {
+    public:
+      ToCmdVel();
+      ~ToCmdVel();
+      void CtrlUpdate();
+    private:
+      void CmdVelCallback(const geometry_msgs::Twist::ConstPtr &msg);
+      void CurStateCallback(const nav_msgs::Odometry::ConstPtr &msg);
+
+      // node handler
+      ros::NodeHandle nh_;
+      
+      // subscriber
+      ros::Subscriber cmd_vel_sub_;
+      ros::Subscriber current_state_sub_;
+      // publisher
+      ros::Publisher control_msg_pub_;
+
+      // tmp_messages
+      geometry_msgs::Twist cmd_vel_;
+      nav_msgs::Odometry current_state_;
+
+      // subscribe message mutex
+      std::mutex cmd_vel_mtx_;
+      std::mutex current_state_mtx_;
+      
+      // parameters
+      double wheel_base_;
+      double max_steer_angle_;
+      double max_vel_;
+      double k_throttle_;
+      double k_brake_;
+      double pub_rate_;
+    };
+  }
+}
+
+#endif

--- a/prius_msg_converter/include/to_cmd_vel.hpp
+++ b/prius_msg_converter/include/to_cmd_vel.hpp
@@ -46,8 +46,10 @@ namespace prius {
       double wheel_base_;
       double max_steer_angle_;
       double max_vel_;
-      double k_throttle_;
-      double k_brake_;
+      double kp_throttle_;
+      double ki_throttle_;
+      double kp_brake_;
+      double ki_brake_;
       double pub_rate_;
     };
   }

--- a/prius_msg_converter/launch/to_cmd_vel.launch
+++ b/prius_msg_converter/launch/to_cmd_vel.launch
@@ -3,8 +3,10 @@
     <param name="wheel_base" value="2.7" type="double"/>
     <param name="max_steer_angle" value="0.47891" type="double"/>
     <param name="max_velocity" value="37.9983" type="double"/>
-    <param name="k_throttle" value="1.0" type="double"/>
-    <param name="k_brake" value="1.0" type="double"/>
+    <param name="kp_throttle" value="0.75" type="double"/>
+    <param name="ki_throttle" value="0.2" type="double"/>
+    <param name="kp_brake" value="0.5" type="double"/>
+    <param name="ki_brake" value="0.1" type="double"/>
     <param name="publish_rate" value="50" type="double"/>
   </node>
 </launch>

--- a/prius_msg_converter/launch/to_cmd_vel.launch
+++ b/prius_msg_converter/launch/to_cmd_vel.launch
@@ -1,0 +1,10 @@
+<launch>
+  <node name="prius_msg_to_cmd_vel_node" pkg="prius_msg_converter" type="prius_msg_to_cmd_vel" output="screen">
+    <param name="wheel_base" value="2.7" type="double"/>
+    <param name="max_steer_angle" value="0.47891" type="double"/>
+    <param name="max_velocity" value="37.9983" type="double"/>
+    <param name="k_throttle" value="1.0" type="double"/>
+    <param name="k_brake" value="1.0" type="double"/>
+    <param name="publish_rate" value="50" type="double"/>
+  </node>
+</launch>

--- a/prius_msg_converter/package.xml
+++ b/prius_msg_converter/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>prius_msg_converter</name>
+  <version>0.0.1</version>
+  <description>The prius_msg_converter package</description>
+
+  <maintainer email="groadpg@gmail.com">RyodoTanaka</maintainer>
+
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <depend>roslaunch</depend>
+  <depend>roscpp</depend>
+  <depend>prius_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>nav_msgs</depend>
+
+</package>

--- a/prius_msg_converter/src/to_cmd_vel.cpp
+++ b/prius_msg_converter/src/to_cmd_vel.cpp
@@ -1,0 +1,153 @@
+#include <to_cmd_vel.hpp>
+
+#include <cmath>
+
+namespace pmc = prius::msg_converter;
+
+pmc::ToCmdVel::ToCmdVel():
+  wheel_base_(3.0),
+  max_steer_angle_(0.6458),
+  max_vel_(38.0),
+  k_throttle_(0.1),
+  k_brake_(0.1),
+  pub_rate_(25.0)
+{
+  nh_.param<double>(ros::this_node::getName() + "/wheel_base", wheel_base_, wheel_base_);
+  nh_.param<double>(ros::this_node::getName() + "/max_steer_angle", max_steer_angle_, max_steer_angle_);
+  nh_.param<double>(ros::this_node::getName() + "/max_velocity", max_vel_, max_vel_);
+  nh_.param<double>(ros::this_node::getName() + "/k_throttle", k_throttle_, k_throttle_);
+  nh_.param<double>(ros::this_node::getName() + "/k_brake", k_brake_, k_brake_);
+  nh_.param<double>(ros::this_node::getName() + "/publish_rate", pub_rate_);
+
+  control_msg_pub_ = nh_.advertise<prius_msgs::Control>("/prius", 1);
+
+  cmd_vel_sub_ = nh_.subscribe("/cmd_vel", 1, &pmc::ToCmdVel::CmdVelCallback, this);
+  current_state_sub_ = nh_.subscribe("/base_pose_ground_truth", 1, &pmc::ToCmdVel::CurStateCallback, this);
+}
+
+pmc::ToCmdVel::~ToCmdVel(){ }
+
+void pmc::ToCmdVel::CmdVelCallback(const geometry_msgs::Twist::ConstPtr &msg)
+{
+  cmd_vel_mtx_.lock();
+  cmd_vel_ = *msg;
+  cmd_vel_mtx_.unlock();
+}
+
+void pmc::ToCmdVel::CurStateCallback(const nav_msgs::Odometry::ConstPtr &msg)
+{
+  current_state_mtx_.lock();
+  current_state_ = *msg;
+  current_state_mtx_.unlock();
+}
+
+void pmc::ToCmdVel::CtrlUpdate()
+{  
+  static ros::Rate r(pub_rate_);
+  static prius_msgs::Control ctrl_msg;
+  
+  while(ros::ok()){
+    ros::spinOnce();
+    
+    // get current state
+    static double current_vel = 0;
+    current_state_mtx_.lock();
+    current_vel = sqrt(pow(current_state_.twist.twist.linear.x,2)+pow(current_state_.twist.twist.linear.y,2));
+    current_state_mtx_.unlock();
+
+    // get objective velocity
+    static double obj_vel = 0;
+    static double obj_ang_vel = 0;
+    cmd_vel_mtx_.lock();
+    obj_vel = cmd_vel_.linear.x;
+    obj_ang_vel = cmd_vel_.angular.z;
+    cmd_vel_mtx_.unlock();
+
+    std::cout << "obj_vel : ";
+    std::cout << obj_vel << std::endl;
+    std::cout << "current_vel :";
+    std::cout << current_vel << std::endl;
+    
+    // set time stamp for control input
+    ctrl_msg.header.stamp = ros::Time::now();
+    
+    // calculate control steer angle
+    static double ctrl_angle = 0;
+    ctrl_angle = atan((wheel_base_*obj_ang_vel)/current_vel)/(2.0*max_steer_angle_);
+    ctrl_angle = std::fabs(ctrl_angle) > 1.0 ? ctrl_angle/std::fabs(ctrl_angle) : ctrl_angle;
+
+    ctrl_msg.steer = ctrl_angle;
+
+    // calculate throttle & shift gear input
+    if(obj_vel==0){
+      ctrl_msg.throttle = 0.0;
+      ctrl_msg.brake = 1.0;
+      ctrl_msg.steer = 0.0;
+      std::cout << "brake :";
+      std::cout << ctrl_msg.brake << std::endl;
+      std::cout << "throttle : ";
+      std::cout << ctrl_msg.throttle << std::endl;
+      control_msg_pub_.publish(ctrl_msg);
+      r.sleep();
+    }
+    else if(obj_vel>0){
+      ctrl_msg.throttle = 0.0;
+      ctrl_msg.brake = 0.0;
+      ctrl_msg.shift_gears = prius_msgs::Control::FORWARD;
+    }
+    else{
+      ctrl_msg.throttle = 0.0;
+      ctrl_msg.brake = 0.0;
+      ctrl_msg.shift_gears = prius_msgs::Control::REVERSE;
+    }
+      
+    static double err_vel = 0;
+    static double ctrl_vel = 0;
+    err_vel = std::fabs(obj_vel) - current_vel;
+    std::cout << "err_vel : ";
+    std::cout << err_vel << std::endl;
+    
+    switch(ctrl_msg.shift_gears){
+    case prius_msgs::Control::FORWARD:
+      if(0<err_vel){
+        ctrl_vel = k_throttle_ * std::fabs(err_vel);
+        ctrl_vel = std::fabs(ctrl_vel) >= 1.0 ? 1.0 : ctrl_vel;
+        ctrl_msg.throttle = ctrl_vel;
+      }
+      else{
+        ctrl_vel = k_brake_ * std::fabs(err_vel);
+        ctrl_vel = std::fabs(ctrl_vel) >= 1.0 ? 1.0 : ctrl_vel;
+        ctrl_msg.brake = ctrl_vel;   
+      }
+      break;
+    case prius_msgs::Control::REVERSE:
+      if(0<err_vel){
+        ctrl_vel = k_throttle_ * std::fabs(err_vel);
+        ctrl_vel = std::fabs(ctrl_vel) >= 1.0 ? 1.0 : ctrl_vel;
+        ctrl_msg.throttle = ctrl_vel;
+      }
+      else{
+        ctrl_vel = k_brake_ * std::fabs(err_vel);
+        ctrl_vel = std::fabs(ctrl_vel) >= 1.0 ? 1.0 : ctrl_vel;
+        ctrl_msg.brake = ctrl_vel;   
+      }
+      break;
+    default:
+      break;
+    }
+ 
+    std::cout << "brake :";
+    std::cout << ctrl_msg.brake << std::endl;
+    std::cout << "throttle : ";
+    std::cout << ctrl_msg.throttle << std::endl;
+  
+    // publish the ctrl msg
+    control_msg_pub_.publish(ctrl_msg);
+    r.sleep();
+
+  }
+}
+
+
+
+

--- a/prius_msg_converter/src/to_cmd_vel.cpp
+++ b/prius_msg_converter/src/to_cmd_vel.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 
 namespace pmc = prius::msg_converter;
+using namespace std;
 
 pmc::ToCmdVel::ToCmdVel():
   wheel_base_(3.0),
@@ -79,7 +80,7 @@ void pmc::ToCmdVel::CtrlUpdate()
     // calculate control steer angle
     static double ctrl_angle = 0;
     ctrl_angle = atan((wheel_base_*obj_ang_vel)/current_vel)/(2.0*max_steer_angle_);
-    ctrl_angle = std::fabs(ctrl_angle) > 1.0 ? ctrl_angle/std::fabs(ctrl_angle) : ctrl_angle;
+    ctrl_angle = fabs(ctrl_angle) > 1.0 ? ctrl_angle/fabs(ctrl_angle) : ctrl_angle;
 
     ctrl_msg.steer = ctrl_angle;
 
@@ -110,7 +111,7 @@ void pmc::ToCmdVel::CtrlUpdate()
     static double err_vel = 0;
     static double err_int_vel = 0;
     static double ctrl_vel = 0;
-    err_vel = std::fabs(obj_vel) - current_vel;
+    err_vel = fabs(obj_vel) - current_vel;
 
     ROS_DEBUG_STREAM_NAMED("statement","error veolocity : " << err_vel);
     ROS_DEBUG_STREAM_NAMED("statement","integration error veolocity : " << err_int_vel);
@@ -119,28 +120,28 @@ void pmc::ToCmdVel::CtrlUpdate()
     case prius_msgs::Control::FORWARD:
       if(0<err_vel){
         err_int_vel += err_vel;
-        ctrl_vel = kp_throttle_*std::fabs(err_vel) + ki_throttle_*std::fabs(err_int_vel);
-        ctrl_vel = std::fabs(ctrl_vel) >= 1.0 ? 1.0 : ctrl_vel;
+        ctrl_vel = kp_throttle_*fabs(err_vel) + ki_throttle_*fabs(err_int_vel);
+        ctrl_vel = fabs(ctrl_vel) >= 1.0 ? 1.0 : ctrl_vel;
         ctrl_msg.throttle = ctrl_vel;
       }
       else{
         err_int_vel -= err_vel;
-        ctrl_vel = kp_brake_*std::fabs(err_vel) + ki_brake_*std::fabs(err_int_vel);
-        ctrl_vel = std::fabs(ctrl_vel) >= 1.0 ? 1.0 : ctrl_vel;
+        ctrl_vel = kp_brake_*fabs(err_vel) + ki_brake_*fabs(err_int_vel);
+        ctrl_vel = fabs(ctrl_vel) >= 1.0 ? 1.0 : ctrl_vel;
         ctrl_msg.brake = ctrl_vel;   
       }
       break;
     case prius_msgs::Control::REVERSE:
       if(0<err_vel){
         err_int_vel -= err_vel;
-        ctrl_vel = kp_throttle_*std::fabs(err_vel) + ki_throttle_*std::fabs(err_int_vel);
-        ctrl_vel = std::fabs(ctrl_vel) >= 1.0 ? 1.0 : ctrl_vel;
+        ctrl_vel = kp_throttle_*fabs(err_vel) + ki_throttle_*fabs(err_int_vel);
+        ctrl_vel = fabs(ctrl_vel) >= 1.0 ? 1.0 : ctrl_vel;
         ctrl_msg.throttle = ctrl_vel;
       }
       else{
         err_int_vel += err_vel;
-        ctrl_vel = kp_brake_*std::fabs(err_vel) + ki_brake_*std::fabs(err_int_vel);
-        ctrl_vel = std::fabs(ctrl_vel) >= 1.0 ? 1.0 : ctrl_vel;
+        ctrl_vel = kp_brake_*fabs(err_vel) + ki_brake_*fabs(err_int_vel);
+        ctrl_vel = fabs(ctrl_vel) >= 1.0 ? 1.0 : ctrl_vel;
         ctrl_msg.brake = ctrl_vel;   
       }
       break;

--- a/prius_msg_converter/src/to_cmd_vel.cpp
+++ b/prius_msg_converter/src/to_cmd_vel.cpp
@@ -30,6 +30,13 @@ pmc::ToCmdVel::ToCmdVel():
   cmd_vel_sub_ = nh_.subscribe("/cmd_vel", 1, &pmc::ToCmdVel::CmdVelCallback, this);
   current_state_sub_ = nh_.subscribe("/base_pose_ground_truth", 1, &pmc::ToCmdVel::CurStateCallback, this);
 
+  // publish to stop
+  prius_msgs::Control ctrl_msg;
+  ctrl_msg.throttle = 0.0;
+  ctrl_msg.brake = 1.0;
+  ctrl_msg.steer = 0.0;
+  control_msg_pub_.publish(ctrl_msg);
+    
   ROS_INFO("Prius message converter is ready.");
 }
 

--- a/prius_msg_converter/src/to_cmd_vel_node.cpp
+++ b/prius_msg_converter/src/to_cmd_vel_node.cpp
@@ -1,0 +1,12 @@
+#include <to_cmd_vel.hpp>
+
+#include <ros/ros.h>
+
+namespace pmc = prius::msg_converter;
+
+int main(int argc, char *argv[])
+{
+  ros::init(argc, argv, "prius_msg_to_cmd_vel_node");
+  pmc::ToCmdVel pmc_tcv;
+  pmc_tcv.CtrlUpdate();
+}


### PR DESCRIPTION
# Updated
I added message converter from `geometry_msgs::Twist` to `prius_msgs::Control`.

# Subscribe
- `/cmd_vel` : `geometry_msgs::Twist` message as objective control input.
- `/base_pose_ground_truth` : `nav_msgs::Odometry` message as current state (velocity).

# Publish
- `/prius` : `prius_msgs::Control` message as control output.

# Parameters
You can set these parameters for control
- wheel_base : The wheel base length in metric.
- max_steer_angle : The max steer angle in radian.
- max_velocity : The max speed of linear in m/sec.
- kp_throttle : The K gain of PID controller for throttle.
- ki_throttle : The I gain of PID controller for throttle.
- kp_brake : The K gain of PID controller for brake.
- ki_brake : The I gain of PID controller for brake.
- publish_rate : The publish rate of `prius_msg::Control` message.

# Usage
After the `car_demo` simulator is launched,
```bash
$ roslaunch prius_msg_converter to_cmd_vel.launch
```
And publish `geometry::Twist` message into `/cmd_vel` topic.
Then you can control the Prius car in the simulation.